### PR TITLE
⬆️ Bump files with dotnet-file sync

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,6 +30,8 @@ indent_size = 2
 
 # Dotnet code style settings:
 [*.{cs,vb}]
+tab_width = 4
+
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
 # Avoid "this." and "Me." if not necessary
@@ -56,6 +58,9 @@ dotnet_style_require_accessibility_modifiers = omit_if_default:error
 
 # IDE0040: Add accessibility modifiers
 dotnet_diagnostic.IDE0040.severity = error
+
+# IDE1100: Error reading content of source file 'Project.TargetFrameworkMoniker' (i.e. from ThisAssembly)
+dotnet_diagnostic.IDE1100.severity = none
 
 [*.cs]
 # Top-level files are definitely OK

--- a/.github/workflows/includes.yml
+++ b/.github/workflows/includes.yml
@@ -58,7 +58,7 @@ jobs:
           base: main
           branch: markdown-includes
           delete-branch: true
-          labels: docs
+          labels: dependencies
           author: ${{ env.BOT_AUTHOR }}
           committer: ${{ env.BOT_AUTHOR }}
           commit-message: +Mᐁ includes

--- a/.netconfig
+++ b/.netconfig
@@ -23,8 +23,8 @@
 	skip
 [file ".editorconfig"]
 	url = https://github.com/devlooped/oss/blob/main/.editorconfig
-	sha = e81ab754b366d52d92bd69b24bef1d5b1c610634
-	etag = 7298c6450967975a8782b5c74f3071e1910fc59686e48f9c9d5cd7c68213cf59
+	sha = a62c45934ac2952f2f5d54d8aea4a7ebc1babaff
+	etag = b5e919b472a52d4b522f86494f0f2c0ba74a6d9601454e20e4cbaf744317ff62
 	weak
 [file ".gitattributes"]
 	url = https://github.com/devlooped/oss/blob/main/.gitattributes
@@ -83,8 +83,8 @@
 	weak
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	sha = c509be4378ff6789df4f66338cb88119453c0975
-	etag = cbbdc1a4d3030f353f3e5306a6c380238dd4ed0945aad2d56ba87b49fcfcd66d
+	sha = 95b338b9780de6b8ed11f060fed2d300f136ec60
+	etag = 5e73ffebd7aef6fecae5a73d4fb044bf46f3a593ee2858ff1648d9c337e546ad
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
@@ -116,8 +116,8 @@
 	weak
 [file ".github/workflows/includes.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/includes.yml
-	sha = 26e8cb798ce72dec7072db826cc9694d456797bd
-	etag = df06492eeb2daaae4168d71bbb643f5da2693b67cdd58c42ffa44a191ee99b69
+	sha = 2d1fb4ed52b63689f2b20b994512ebac28721243
+	etag = 34ade86f020dea717c6a27ad7dcd0069c35be2832c58b0ba961278a1efe34089
 	weak
 [file ".github/workflows/dotnet-file-core.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file-core.yml

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -43,6 +43,8 @@
 
     <!-- Ensure MSBuild tooling can access package artifacts always via PKG_[PackageId] -->
     <GeneratePathProperty>true</GeneratePathProperty>
+    <!-- Avoid warnings for test projects when we run dotnet pack on the whole solution. -->
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">


### PR DESCRIPTION
# devlooped/oss

- Disable warnings for non-packable test projects https://github.com/devlooped/oss/commit/95b338b
- Revert indent size for project files https://github.com/devlooped/oss/commit/a62c459
- Change label from 'docs' to 'dependencies' https://github.com/devlooped/oss/commit/2d1fb4e